### PR TITLE
Don't pass `CONFIGURE_COMMAND` to `ExternalProject_add` if not requested; fix -s argument

### DIFF
--- a/APPLY.md
+++ b/APPLY.md
@@ -98,6 +98,12 @@ To fix this, we use the `REQUIRES` argument in the recipe for `Carrot`. This doe
 
 In this way, we can build arbitrary acyclic graphs of dependencies with recipes with maximal flexibility in terms of how we provide each ingredient.
 
+#### ExternalProject Arguments
+
+When using ingredients with dependencies of their own, many normal configuration-related `EXTERNAL_PROJECT_ARGS` will not function, given that CMakeCooking overrides the `CONFIGURE_COMMMAND` argument passed to `ExternalProject_add`.  Typically, you'll usually need to tweak the `cmake` args that Cooking will eventually use.  This can usually be accomplished with the `CMAKE_ARGS` argument.
+
+With recipes that have ingredients that do not use Cooking themselves, the full suite of configuration-related `ExternalProject` args is available.  Such recipes will pass `CONFIGURE_COMMAND` to `ExternalProject_add` only if it is provided.
+
 ### Using `cmake-cooking` with integrated development environments (IDEs)
 
 It is very easy to use `cmake-cooking` with IDEs which offer CMake support. A good example is CLion from JetBrains.

--- a/cooking.sh
+++ b/cooking.sh
@@ -639,7 +639,7 @@ function (_cooking_define_ep)
 
   # Arguments that could be set to <DEFAULT> (which will be left unset in the ExternalProject_add
   # invocation) are not even provided to ExternalProject_add.
-  set (ep_defaultable_args_list)
+  set (ep_defaultable_args_list "")
   if (NOT (pa_CONFIGURE_COMMAND STREQUAL "<DEFAULT>"))
     list (APPEND ep_defaultable_args_list CONFIGURE_COMMAND ${pa_CONFIGURE_COMMAND})
   endif()
@@ -658,7 +658,7 @@ function (_cooking_define_ep)
     CMAKE_ARGS ${pa_CMAKE_ARGS}
     LIST_SEPARATOR :::
     STEP_TARGETS install
-    "${ep_defaultable_args_list}
+    "${ep_defaultable_args_list}"
     "${forwarded_ep_args}")
 
   set (stow_marker_file ${Cooking_INGREDIENTS_DIR}/.cooking_ingredient_${pa_NAME})

--- a/cooking.sh
+++ b/cooking.sh
@@ -2,6 +2,7 @@
 
 #
 # Copyright 2018 Jesse Haber-Kucharsky
+# Copyright 2019 Akamai Technologies, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -161,8 +162,13 @@ EOF
 }
 
 parse_assignment() {
-    IFS='=' read -ra parts <<< "${1}"
-    export "${parts[0]}"="${parts[1]}"
+    read -r assignment <<< "${1}"
+    eq_idx=$(expr index "$assignment" '=')
+
+    name=${assignment:0:$(($eq_idx - 1))}
+    value=${assignment:$eq_idx}
+
+    export "${name}"="${value}"
 }
 
 yell_include_exclude_mutually_exclusive() {

--- a/cooking.sh
+++ b/cooking.sh
@@ -597,11 +597,7 @@ function (_cooking_populate_ep_configure_command)
       --
       ${pa_COOKING_CMAKE_ARGS})
   elseif (NOT (CONFIGURE_COMMAND IN_LIST ${pa_EXTERNAL_PROJECT_ARGS_LIST}))
-    set (value
-      CONFIGURE_COMMAND
-      ${CMAKE_COMMAND}
-      ${pa_CMAKE_ARGS}
-      <SOURCE_DIR>)
+    set (value "<DEFAULT>")
   else ()
     set (value "")
   endif ()
@@ -641,13 +637,19 @@ function (_cooking_define_ep)
   set (ep_name ingredient_${pa_NAME})
   include (ExternalProject)
 
+  # Arguments that could be set to <DEFAULT> (which will be left unset in the ExternalProject_add
+  # invocation) are not even provided to ExternalProject_add.
+  set (ep_defaultable_args_list)
+  if (NOT (pa_CONFIGURE_COMMAND STREQUAL "<DEFAULT>"))
+    list (APPEND ep_defaultable_args_list CONFIGURE_COMMAND ${pa_CONFIGURE_COMMAND})
+  endif()
+
   set (stamp_dir ${pa_INGREDIENT_DIR}/stamp)
 
   ExternalProject_add (${ep_name}
     DEPENDS ${pa_DEPENDS}
     SOURCE_DIR ${pa_SOURCE_DIR}
     BINARY_DIR ${pa_BINARY_DIR}
-    CONFIGURE_COMMAND ${pa_CONFIGURE_COMMAND}
     BUILD_COMMAND ${pa_BUILD_COMMAND}
     INSTALL_COMMAND ${pa_INSTALL_COMMAND}
     PREFIX ${pa_INGREDIENT_DIR}
@@ -656,6 +658,7 @@ function (_cooking_define_ep)
     CMAKE_ARGS ${pa_CMAKE_ARGS}
     LIST_SEPARATOR :::
     STEP_TARGETS install
+    "${ep_defaultable_args_list}
     "${forwarded_ep_args}")
 
   set (stow_marker_file ${Cooking_INGREDIENTS_DIR}/.cooking_ingredient_${pa_NAME})


### PR DESCRIPTION
This changes the method by which `cooking_ingredient` passes `CONFIGURE_COMMAND` to `ExternalProject_add`.  It will now only be provided to `ExternalProject_add` if it is explicitly provided or the ingredient in question uses CMakeCooking.  This has the end result of making `cooking_ingredient`'s `EXTERNAL_PROJECT_ARGS` parameter map more neatly to `ExternalProject_add`'s own parameters.

The pitfalls of some configure-related ExternalProject args are now mentioned in APPLY.md.

This change also fixes an issue with the `-s` argument, which sets environment variables.  The previous behavior would, if provided (e.g.):

```
LDFLAGS=-fuse-ld=gold
```

Set `LDFLAGS` to `-fuse-ld`.  The modification will result in everything after the first equals sign to be added to the destination environment variable.

This should fix #5.